### PR TITLE
Add immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,14 @@ This library is not yet published.
 
 ## Example
 
-All sequence types expose an API to return the next item in
-the sequence or the next N items. Sequences manage their own
+All sequence types expose an API to return the next N items. Sequences manage their own
 state.
 
 ```javascript
 import { Arithmetic } from "number-sequences";
 
 const seq = Arithmetic(1, 1);
-
-// Generate items one at a time...
-seq.next(); // 1
-seq.next(); // 2
-seq.next(); // 3
-
-// Or multiple items at the same time
-seq.nextN(3); // [4, 5, 6]
+seq.nextN(3); // [1, 2, 3]
 ```
 
 ## Available sequences

--- a/package-lock.json
+++ b/package-lock.json
@@ -3207,6 +3207,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "immutable": {
+      "version": "4.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
+      "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
+    },
     "import-local": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/jest": "^26.0.10",
+    "immutable": "^4.0.0-rc.12",
     "ts-jest": "^26.3.0",
     "typescript": "^4.0.2"
   },

--- a/src/__tests__/sequence.spec.ts
+++ b/src/__tests__/sequence.spec.ts
@@ -11,21 +11,11 @@ function createGenerator() {
 describe("createSequence", () => {
   it("returns a sequence", () => {
     const sequence = createSequence(createGenerator());
-    expect(sequence.next).toBeInstanceOf(Function);
     expect(sequence.nextN).toBeInstanceOf(Function);
   });
 });
 
 describe("Sequences", () => {
-  describe("#next", () => {
-    it("calculates the next item in the sequence", () => {
-      const sequence = createSequence(createGenerator());
-      expect(sequence.next()).toEqual(1);
-      expect(sequence.next()).toEqual(2);
-      expect(sequence.next()).toEqual(3);
-    });
-  });
-
   describe("#nextN", () => {
     it("calculates the next item in the sequence", () => {
       const sequence = createSequence(createGenerator());

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -1,19 +1,14 @@
+import { Seq } from "immutable";
+
 export interface Sequence {
-  next: () => number;
   nextN: (n: number) => Array<number>;
 }
 
 /**
  * creates a sequence from a generator
  */
-export function createSequence(generator: Generator): Sequence {
-  /**
-   * next
-   * Genreate and return the next item in the sequence
-   */
-  function next(): number {
-    return generator.next().value;
-  }
+export function createSequence(generator: Generator<number>): Sequence {
+  const seq = Seq(generator);
 
   /**
    * nextN
@@ -21,16 +16,10 @@ export function createSequence(generator: Generator): Sequence {
    * @param n the number to generate
    */
   function nextN(n: number): Array<number> {
-    function nextNHelper(n: number, arr: Array<number> = []): Array<number> {
-      return n === 0
-        ? arr
-        : nextNHelper(n - 1, [...arr, generator.next().value]);
-    }
-    return nextNHelper(n);
+    return seq.take(n).toArray();
   }
 
   return {
-    next,
     nextN,
   };
 }

--- a/src/sequenceTypes/arithmetic.ts
+++ b/src/sequenceTypes/arithmetic.ts
@@ -20,7 +20,7 @@ export default function Arithmetic(
 }
 
 // Generator
-function* generator(current = 0, commonDifference = 1): Generator {
+function* generator(current = 0, commonDifference = 1): Generator<number> {
   yield current;
   yield* generator(current + commonDifference, commonDifference);
 }

--- a/src/sequenceTypes/collatz.ts
+++ b/src/sequenceTypes/collatz.ts
@@ -15,7 +15,7 @@ const Collatz = (start: number): Sequence => {
 };
 
 // Generator
-function* generator(current: number): Generator {
+function* generator(current: number): Generator<number> {
   yield current;
   yield* generator(current % 2 === 0 ? current / 2 : 3 * current + 1);
 }

--- a/src/sequenceTypes/fibonacci.ts
+++ b/src/sequenceTypes/fibonacci.ts
@@ -14,7 +14,7 @@ export default function Fibonacci(): Sequence {
 }
 
 // Generator
-function* generator(current = 0, next = 1): Generator {
+function* generator(current = 0, next = 1): Generator<number> {
   yield current;
   yield* generator(next, current + next);
 }

--- a/src/sequenceTypes/geometric.ts
+++ b/src/sequenceTypes/geometric.ts
@@ -20,7 +20,7 @@ export default function Geometric(
 }
 
 // Generator
-function* generator(current = 0, commonRatio = 1): Generator {
+function* generator(current = 0, commonRatio = 1): Generator<number> {
   yield current;
   yield* generator(current * commonRatio, commonRatio);
 }

--- a/src/sequenceTypes/power.ts
+++ b/src/sequenceTypes/power.ts
@@ -14,7 +14,7 @@ const Power = (x: number): Sequence => {
 };
 
 // Generator
-function* generator(current: number, initial?: number): Generator {
+function* generator(current: number, initial?: number): Generator<number> {
   yield current;
   const x = initial || current;
   yield* generator(current * x, x);

--- a/src/sequenceTypes/prime.ts
+++ b/src/sequenceTypes/prime.ts
@@ -22,7 +22,10 @@ const Prime = (): Sequence => {
 };
 
 // Generator
-function* generator(current: number, prev: Array<number> = []): Generator {
+function* generator(
+  current: number,
+  prev: Array<number> = []
+): Generator<number> {
   yield current;
   const largestPrimeSoFar = prev[prev.length - 1];
   const nextPrime = findNextPrime(nextCandidate(largestPrimeSoFar), prev);

--- a/src/sequenceTypes/triangle.ts
+++ b/src/sequenceTypes/triangle.ts
@@ -21,7 +21,7 @@ const Triangle = (): Sequence => {
 // add n + 1 to get the next term
 // e.g. if current term is 10, then the above formula tells us it's the 4th term,
 // so we add 5 to get the 5th term = 15
-function* generator(current: number): Generator {
+function* generator(current: number): Generator<number> {
   yield current;
   const n = (Math.sqrt(1 + 8 * current) - 1) / 2;
   yield* generator(current + n + 1);


### PR DESCRIPTION
* Installs `Immutable.js`
* Adds <number> type assertion to all existing `Generator`s (so they become `Generator<number>`)
* Removes `next` from the API
* Replaces innards of `nextN` with `immutable` equivalent
* Updates readme

As predicted, all tests still pass. Let's put this in and then maybe think about opening up the API to return the whole of Immutable rather than just the one function.